### PR TITLE
Intro updates

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -101,24 +101,26 @@ packages
 \citep{nowbandegani_extremely_2023,fan_likelihood_2023}.
 Infererence methods now tend to fall into two classes: those that
 sample from a statistical
+% TODO add SINGER
 model~\citep{rasmussen_genome-wide_2014,hubisz_mapping_2020,mahmoudi_bayesian_2022}
-or parsimony~\citep{ignatieva_kwarg_2021} and that return
-a fully precise ARG estimate~\citep{wong_general_2023},
+or parsimony~\citep{ignatieva_kwarg_2021,rasmussen_espalier_2022},
 and those based on
 heuristics~\citep{kelleher_inferring_2019,speidel_method_2019,
-zhang_biobank-scale_2023} that return an more approximate structure.
+zhang_biobank-scale_2023}.
 Typically, the more rigorous approaches can handle 10-100 samples,
 while the approximate methods can scale to 10s to hundreds of
-thousands of samples. With the explosive grown in dataset
+thousands of samples. With the explosive growth in dataset
 sizes in recent years~\citep[e.g.][]{bycroft_genome_2018,halldorsson_sequences_2022,
 all_genomic_2024} there is a pressing need for more statistical
 rigor in large scale ARG inference.
 
-Model-based inference is a central element of population genetics.
+Perhaps the clearest route to statistical rigor is through scalable
+model-based inference, a central element of population genetics.
 The coalescent~\citep{kingman_genealogy_1982,kingman_coalescent_1982,hudson_testing_1983,
 tajima_evolutionary_1983} has proved to be a useful model, and is the
-basis of a wide variety of inferences [some citations?]. The incorporation
-of recombination in to the coalescent process~\citep{hudson_properties_1983}
+basis of a wide variety of inferences [some citations, e.g Hey IM model]. 
+The incorporation
+of recombination in the coalescent process~\citep{hudson_properties_1983}
 has proved to be much more difficult.
 % FIXME rephrase, next two sentences, lifted from ARG paper
 Early work on inference under the coalescent with recombination
@@ -146,138 +148,39 @@ like ARGweaver~\citep{rasmussen_genome-wide_2014}, which remains the
 % TODO list other places ARGweaver has come out on top in terms of accuracy.
 gold-standard in terms of accuracy~\citep{brandt2022evaluation}
 
+% THE PROBLEM!!! OMG it's terrible!!!
+Although major breakthroughs in scale have been achieved by hueristic
+ARG inference
+methods~\citep{kelleher_inferring_2019,speidel_method_2019,zhang_biobank-scale_2023},
+these methods are currently fundamentally incompatible with rigorous
+inference under population genetic models such as the SMC. This is 
+because these methods return approximate ARG
+\emph{structures}~\citep{wong_general_2023} [WEAK, FIXME]. Specifically,
+we cannot evaluate a likelihood of these ARGs in coalescent 
+models under the classical 
+\cite{kuhner_maximum_2000} formulation, as these formulations assume
+that complete information about recombination events is present.
+[NOTE the following is super weak, and needs a lot of work.]
+This inability to connect the results of large-scale inference methods
+with a generative model
+is a fundamental limitation, and limits both the utility of 
+current point estimates as well as the possibilities for further
+inference. Specifically, we are unable to quantify uncertainty 
+around heuristic point estimates. We cannot explore ARG space
+around the point estimates using (e.g. MCMC), as we have no way definition
+of improvement. We cannot compare models of demography, or evaluate the 
+goodness of fit for model estimates.
 
-\begin{itemize}
-    \item Problem: we can't use models on inferred ARGs (Relate, tsinfer, ARGneedle). These methods produce point estimates. What we can't do:
-        \begin{itemize}
-            \item quantify uncertainty
-            \item explore ARG space systematically around the point estimates. We don't have a metric on what an improvement might be.
-            \item compare models of demography
-            \item can't evaluate goodness of fit of model estimates
-        \end{itemize}
-    \item what we do here
-\end{itemize}
-
-
-[TL;DR]: way to think about genealogies is tied to the CwR. However,
-CwR does not enable us to simply compute a likelihood in the absence of a fully
-detailed history. In the past, this has given rise to approximations to the
-coalescent that had similar properties yet were significantly easier to use
-as a basis for inference.
-A similar process has taken place in ARG-based inference,
-where scalable ARG inference has been made possible due to both these approximations
-to the coalescent as well as the idea of ARGs without explicit, fully detailed
-recombination histories. What is left however is to connect the two.]
-
-%% ARGs are awesome, or general intro about approximations
-
-[FIX ME: introduction is very much work in progress.
-start is a mess. Need to find the right way in.]
-Knowledge of the exact genealogy of a set of samples would make certain problems
-in population genetics (e.g.\ inferring recombination rates) trivial.
-Recent advancements in large-scale inference methods of the intricately
-interwoven paths of inheritance referred to as ancestral recombination graphs (ARGs)
-\citep{rasmussen_genome-wide_2014, heine_bridging_2018,
-kelleher_inferring_2019, speidel_method_2019, rasmussen_espalier_2022, zhang_biobank-scale_2023},
-are revolutionising the way we look at large genomic datasets.
-
-Quite a number of studies have started to demonstrate the value of the recent ability to
-infer ARGs at scale by emphasizing the ability to rephrase many fundamental problems
-in genomics as questions on the transmission of genetic material from generation
-to generation [REFS].
-Yet even though the potential of ARGs in population and statistical genetics has
-been demonstrated, the fact that these inferred ARGs lack explicit detail on
-recombination events means that it remains unclear how to connect these
-reconstructed ARGs to the stochastic/generative models that have lead us
-to study these datastructures in the first place.
-
-For a very long time people have assumed that what is meant by an ARG is the
-fully specified genealogical history where all events are uniquely positioned
-both in time and along the genome [Wong et al. 2023].
-Yet, the ease by which such a fully detailed history can be simulated under the
-CwR, is not matched by the usability of the model for inference.
-In particular, given an ARG, there will always be an infinite amount of other
-ARGs that could have generated the observed genomic dataset
-[potentially with very different likelihoods under the CwR]
-\citep{mcvean_approximating_2005}.
-
-%% approximations have driven the rate of progress in inference
-Instead, approximations of the coalescence with recombination (CwR) have
-driven our ability to perform statistical genomic inference. Two approximations
-in particular have proven to be instrumental: the sequentially Markovian coalescent,
-and its extensions (SMC) on the one hand, and the Li and Stephens model on the other.
-The impact of both models is tightly linked to the fact that they have enabled
-the reformulation of inference problems as hidden Markov models (HMM) and thus
-the use of the well-known efficient HMM-algorithms.
-
-To improve the ability to simulate the CwR, McVean and Cardin
-provided an approximation of the CwR that is both Markovian backwards in time
-as well as left-to-right along the genome \citep{mcvean_approximating_2005}.
-By sacrificing precision on our ability to capture long range linkage
-information, the SMC became the engine of many powerful inference methods [PSMC].
-A later improvement, the SMC', closed the gap between the SMC and the
-CwR even further.
-
-The second key approximation is not a generative model. Rather than providing
-a mathematical description of the genealogies underlying the observed data
-the Li and Stephens or copying model pragmatically details the relationship
-of a single genome to a larger set of genomes as the result of an
-incomplete copying process \citep{li_modeling_2003}. This heuristic approach
-has been successfully applied for demographic inference [and other things: ADD]
-\citep{sheehan_estimating_2013, steinrucken_inference_2019}.
-
-Both approaches have further formed the basis (of many) of the recent advancements in
-ARG inference methods \citep{rasmussen_genome-wide_2014, heine_bridging_2018,
-kelleher_inferring_2019, speidel_method_2019, rasmussen_espalier_2022, zhang_biobank-scale_2023}.
-A further classification of these methods could be made based on the level of detail
-that is provided on recombination events. The first real breakthrough in large-scale
-ARG inference, \argweaver, heads the first group.
-The ARGs sampled by \argweaver from the posterior distribution
-given the observed variational data, are all fully precise and detailed in the sense
-that all events are explicitly inferred. Note however that the set of possible node times
-has to be limited to enable the usage of an HMM. The other more recent methods, although
-still SMC-based, have added heuristic pre- and/or post-processing steps
-that have allowed them to extend their approach to larger sample sizes. We should also
-mention \kwarg and \texttt{ARGinfer} in this category of methods producing fully detailed ARGs
-although these are not based on the SMC or the copying algorithm. In fact they represent
-two extremes along the approximation continuum with \kwarg being entirely
-parsimony-based while \texttt{ARGinfer} is a CwR-based MCMC sampler.
-
-
-%% Recent progress in ARGs through approximate structures}
-
-The second group of methods (\tsinfer, \relate, \argneedle) has marked a significant
-leap in scalability. These methods derive their scalability at least to a certain
-degree from the fact that the ARGs they infer are approximate structures. In particular,
-recombination is an emergent property of the inferred ARGs, explaining tree topology
-changes going from one local tree to the next. The recombination events themselves
-are not explicitly inferred and are thus not part of the resulting data structure.
-
-The computational gains from not having to pinpoint recombination events tie in
-with the inevitable uncertainty associated with ARG reconstruction [Hayman, 2022, ADD REFS].
-Some approaches have embraced the approximate nature of the resulting ARG by, for
-example, highlighting the inability to resolve certain splits and instead representing
-them as polytomies \citep{kelleher_inferring_2019}. Taken together this means that the
-degree of completeness in which genetic inheritance from ancestors to descendants is documented
-by each of these methods varies extensively.
-[TO ADD: these methods only provide point estimates]
-
-%% The Big problem: how do you connect such approximate structures to a generative model
-
-This has complicated the ability to connect the output of this diverse range of
-ARG inference methods to a model-based description that would allow us to perform
-probabilistic exploration of the ARG space around the point estimate,
-or likelihood-based inference.
-
-%% what we will do
-Here, the idea is to bridge this gap and use the backwards-in-time formulation of the SMC
-to compute likelihoods for for \textit{any} inferred ARG
-by integrating out the time to recombination.
-The application of the SMC in a way that resonates more
-with the true direction of flow of genetic information
-results in a concrete way to formulate an algorithm
-that is \textit{general} in the sense that it can deal with the various levels of
-completeness that characterise the current state of the field of ARG reconstruction.
+%% This is how we solve it
+[TODO figure out the gARG, tree sequence etc mess]
+Here, we bridge this gap between models and the products of approximate
+inference by defining a likelihood function for any 
+``genome ARG''~\citep{wong_general_2023} under the SMC. Using a novel
+formulation of the SMC that focuses on the contributions of nodes and 
+edges [FIXME] in a backwards-in-time way, we provide an efficient 
+algorithm that can compute a likelihood for any gARG under this model.
+We demonstrate the flexibility of this approach by XXX, and show
+[SOMETHING]. 
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -816,6 +719,44 @@ with sampling from subset of all compatible genealogies. Uncertainty could also
 be quantified and passed on as metadata to the nodes in the data format storing the ARG.
 % can something similar be done for stacked recombinations?
 
+%% NOTE: this is some orphan text from the intro that can be rejiggered for the 
+% discussion. We can talk about precision of recombination estimates a bit 
+% here I think, as it is an important topic.
+
+% Both approaches have further formed the basis (of many) of the recent advancements in
+% ARG inference methods \citep{rasmussen_genome-wide_2014, heine_bridging_2018,
+% kelleher_inferring_2019, speidel_method_2019, rasmussen_espalier_2022, zhang_biobank-scale_2023}.
+% A further classification of these methods could be made based on the level of detail
+% that is provided on recombination events. The first real breakthrough in large-scale
+% ARG inference, \argweaver, heads the first group.
+% The ARGs sampled by \argweaver from the posterior distribution
+% given the observed variational data, are all fully precise and detailed in the sense
+% that all events are explicitly inferred. Note however that the set of possible node times
+% has to be limited to enable the usage of an HMM. The other more recent methods, although
+% still SMC-based, have added heuristic pre- and/or post-processing steps
+% that have allowed them to extend their approach to larger sample sizes. We should also
+% mention \kwarg and \texttt{ARGinfer} in this category of methods producing fully detailed ARGs
+% although these are not based on the SMC or the copying algorithm. In fact they represent
+% two extremes along the approximation continuum with \kwarg being entirely
+% parsimony-based while \texttt{ARGinfer} is a CwR-based MCMC sampler.
+
+%% Recent progress in ARGs through approximate structures}
+
+% The second group of methods (\tsinfer, \relate, \argneedle) has marked a significant
+% leap in scalability. These methods derive their scalability at least to a certain
+% degree from the fact that the ARGs they infer are approximate structures. In particular,
+% recombination is an emergent property of the inferred ARGs, explaining tree topology
+% changes going from one local tree to the next. The recombination events themselves
+% are not explicitly inferred and are thus not part of the resulting data structure.
+
+% The computational gains from not having to pinpoint recombination events tie in
+% with the inevitable uncertainty associated with ARG reconstruction [Hayman, 2022, ADD REFS].
+% Some approaches have embraced the approximate nature of the resulting ARG by, for
+% example, highlighting the inability to resolve certain splits and instead representing
+% them as polytomies \citep{kelleher_inferring_2019}. Taken together this means that the
+% degree of completeness in which genetic inheritance from ancestors to descendants is documented
+% by each of these methods varies extensively.
+% [TO ADD: these methods only provide point estimates]
 
 
 \section{Data availability}

--- a/paper.tex
+++ b/paper.tex
@@ -46,13 +46,10 @@
 
 % First authors
 \author[1, $\dagger$]{Gertjan Bisschop}
-
-% Middle Authors
-\author[2]{Alison Etheridge}
+\author[1]{Jerome Kelleher}
+% last author
 \author[3]{Peter Ralph}
 
-% last author
-\author[1]{Jerome Kelleher}
 \affil[$\dagger$]{Denotes corresponding author}
 
 \maketitle


### PR DESCRIPTION
A few updates:

- Changed author order to remove Alison and make @petrelharp last (as Peter and I discussed earlier today). Is this OK with you @GertjanBisschop?
- Tidied up the introduction to give skeletons of the last two paragraphs, and deleted stuff we want to avoid like Li and Stephens
- Moved some nice text about approximate structures etc to the end

I think the goal of the intro here is to give just enough context to convince the reader that there is a problem, and to push off the hairy technical details until later. We can get into approximate structures and precision of recombination information in the Discussion a bit I think, but we don't want to confuse people too much at the outset.

Current intro draft of the last two paras is super rough, but I think it's roughly showing the right direction.